### PR TITLE
email signature property should be staffsignature instead of signature

### DIFF
--- a/lib/kayako_client/staff.rb
+++ b/lib/kayako_client/staff.rb
@@ -26,7 +26,7 @@ module KayakoClient
         property :full_name,      :string, :readonly => true
         property :email,          :string, :required => [ :put, :post ]
         property :designation,    :string
-        property :signature,      :string
+        property :staffsignature, :string
         property :greeting,       :string
         property :mobile_number,  :string
         property :is_enabled,     :boolean


### PR DESCRIPTION
According to the Kayako REST API Reference the email signature property is <pre>StaffSignature</pre> not <pre>Signature</pre>